### PR TITLE
remove deprecated PurchasedCount property

### DIFF
--- a/EOS/Scripts/IEOS.cs
+++ b/EOS/Scripts/IEOS.cs
@@ -3161,7 +3161,6 @@ public class IEOS : Node
             {"price_result", data?.PriceResult},
             {"discount_percentage", (int)data?.DiscountPercentage},
             {"expiration_timestamp", data?.ExpirationTimestamp},
-            {"purchased_count", (int)data?.PurchasedCount},
             {"purchased_limit", data?.PurchaseLimit},
             {"available_for_purchase", data?.AvailableForPurchase},
             {"original_price", data?.OriginalPrice64},


### PR DESCRIPTION
Remove deprecated `PurchasedCount` field from `CatalogOffer`.

The field causes solution build failures when using the newest EOS C# SDK version (1.15.4), so there are 2 solutions - either renaming it to `PurchasedCount_DEPRECATED` or removing it entirely. I propose to remove it since, according to the [documentation](https://dev.epicgames.com/docs/api-ref/structs/eos-ecom-catalog-offer), the backend does not return it anymore.