### PR TITLE
feat: add Platform NetworkStatus get and set

### DIFF
--- a/EOS/Scripts/EOS.gd
+++ b/EOS/Scripts/EOS.gd
@@ -577,6 +577,12 @@ class Platform:
 		Foreground = 3
 	}
 
+	enum NetworkStatus {
+		Disabled = 0,
+		Offline = 1
+		Online = 2
+	}
+
 	class InitializeOptions extends BaseClass:
 		func _init().("InitializeOptions"): pass
 
@@ -640,6 +646,11 @@ class Platform:
 		static func set_override_locale_code(locale_code: String) -> Dictionary:
 			return IEOS.platform_interface_set_override_locale_code(locale_code)
 
+		static func set_network_status(new_status: int) -> int:
+			return IEOS.platform_interface_set_network_status(new_status)
+
+		static func get_network_status() -> int:
+			return IEOS.platform_interface_get_network_status()
 
 class Ecom:
 	enum ItemType { Durable = 0, Consumable = 1, Other = 2 }

--- a/EOS/Scripts/IEOS.cs
+++ b/EOS/Scripts/IEOS.cs
@@ -436,6 +436,15 @@ public class IEOS : Node
         return s_PlatformInterface.SetOverrideLocaleCode(locale_code);
     }
 
+    public int platform_interface_get_network_status()
+    {
+        return (int)s_PlatformInterface.GetNetworkStatus();
+    }
+
+    public Result platform_interface_set_network_status(NetworkStatus newStatus)
+    {
+        return s_PlatformInterface.SetNetworkStatus(newStatus);
+    }
 
     // -----
     // Auth Interface


### PR DESCRIPTION
Add wrappers for the following `Platform` APIs:

* [EOS_Platform_GetNetworkStatus](https://dev.epicgames.com/docs/en-US/api-ref/functions/eos-platform-get-network-status)
* [EOS_Platform_SetNetworkStatus](https://dev.epicgames.com/docs/en-US/api-ref/functions/eos-platform-set-network-status)