### PR TITLE
feat: add abstractions for manual graceful shutdown

### DIFF
--- a/EOS/Scripts/EOS.gd
+++ b/EOS/Scripts/EOS.gd
@@ -625,6 +625,12 @@ class Platform:
 		static func create(options: CreateOptions) -> bool:
 			return IEOS.platform_interface_create(options)
 
+		static func release() -> void:
+			IEOS.platform_interface_release()
+
+		static func shutdown() -> int:
+			return IEOS.platform_interface_shutdown()
+
 		static func check_for_launcher_and_restart() -> int:
 			return IEOS.platform_interface_check_for_launcher_and_restart()
 

--- a/EOS/Scripts/IEOS.cs
+++ b/EOS/Scripts/IEOS.cs
@@ -446,6 +446,19 @@ public class IEOS : Node
         return s_PlatformInterface.SetNetworkStatus(newStatus);
     }
 
+    public void platform_interface_release()
+    {
+        if (s_PlatformInterface != null)
+        {
+            s_PlatformInterface.Release();
+        }
+    }
+
+    public Result platform_interface_shutdown()
+    {
+        return PlatformInterface.Shutdown();
+    }
+
     // -----
     // Auth Interface
     // -----


### PR DESCRIPTION
Add abstractions for [EOS_Platform_Release](https://dev.epicgames.com/docs/api-ref/functions/eos-platform-release) and [EOS_Shutdown](https://dev.epicgames.com/docs/api-ref/functions/eos-shutdown).

```gdscript
EOS.Platform.PlatformInterface.release()
EOS.Platform.PlatformInterface.shutdown()
```