### PR TITLE
mono_object_to_variant_impl fix for QueryOwnership

### DIFF
--- a/EOS/Scripts/IEOS.cs
+++ b/EOS/Scripts/IEOS.cs
@@ -2357,10 +2357,10 @@ public class IEOS : Node
                 {"client_data", data.ClientData},
                 {"local_user_id", data.LocalUserId?.ToString()},
                 {"item_ownership",
-                    data.ItemOwnership?.Select(x => new Dictionary(){
+                    new Godot.Collections.Array(data.ItemOwnership?.Select(x => new Dictionary(){
                         {"id", x.Id?.ToString()},
                         {"ownership_status", x.OwnershipStatus},
-                    }).ToArray()
+                    }))
                 }
             };
             EmitSignal(nameof(ecom_interface_query_ownership_callback), ret);


### PR DESCRIPTION
The callback handler for EcomInterface.QueryOwnership raises the following exception

`mono_object_to_variant_impl: Attempted to convert a managed array of unmarshallable element type to Variant.`

This is probably also needed for other return values where an array of godot dictionaries is being returned, but for now I just verified QueryOwnership since that's what I'm currently working with right now.