### PR TITLE
Fixed typo (reuslt -> result)

### DIFF
--- a/src/connect_interface.cpp
+++ b/src/connect_interface.cpp
@@ -200,7 +200,7 @@ void IEOS::connect_interface_create_user(Ref<RefCounted> p_options) {
 
     EOS_Connect_CreateUser(s_connectInterface, &options, (void*)*p_options, [](const EOS_Connect_CreateUserCallbackInfo* data) {
         Dictionary ret;
-        ret["reuslt_code"] = static_cast<int>(data->ResultCode);
+        ret["result_code"] = static_cast<int>(data->ResultCode);
         Ref<RefCounted> client_data = reinterpret_cast<RefCounted*>(data->ClientData);
         client_data->unreference();
         ret["client_data"] = client_data->get("client_data");


### PR DESCRIPTION
Hi! I'm getting familiar with this addon by using it in a game jam to add a leaderboard to my game.

I noticed reuslt_code was spelled wrong in EOS_Connect_CreateUser, so putting up a PR to fix the typo.

Thanks for creating this addon, it's awesome!