### PR TITLE
Fixed bugs and docs. Add checks to socket ids.

### DIFF
--- a/src/eosg_multiplayer_peer.h
+++ b/src/eosg_multiplayer_peer.h
@@ -173,6 +173,7 @@ private:
 
         void close();
         void clear_packets_from_peer(int p_peer);
+        bool _socket_id_is_valid(const String &socket_id);
 
         EOSGSocket() {}
 
@@ -181,6 +182,8 @@ private:
         }
 
         EOSGSocket(const String &socket_name) {
+            memset(socket.SocketName, 0, sizeof(socket.SocketName));
+            ERR_FAIL_COND_MSG(!_socket_id_is_valid(socket_name), "Failed to create socket. Socket id is not valid.\nNOTE: Socket id cannot be empty, must only have alpha-numeric characters, and must not be longer than 32 characters");
             socket.ApiVersion = EOS_P2P_SOCKETID_API_LATEST;
             STRNCPY_S(socket.SocketName, EOS_P2P_SOCKETID_SOCKETNAME_SIZE, socket_name.utf8(), socket_name.length());
         }
@@ -208,7 +211,7 @@ private:
     TransferMode transfer_mode = TransferMode::TRANSFER_MODE_RELIABLE;
     uint32_t transfer_channel = CH_RELIABLE;
     bool refusing_connections = false;
-    bool polling = true;
+    bool polling = false;
 
     HashMap<uint32_t, EOS_ProductUserId> peers;
 


### PR DESCRIPTION
Fixed a bug where multiplayer peers were not able to ever receive EOS_EConnectionClosedReason::EOS_CCR_ClosedByLocalUser notifications due to peers being removed from the mediator too quickly when they close.

Fixed some issues with the comments that document methods.

Added verification for socket ids when a new EOSGSocket is created when starting a server, client, or mesh. It now checks to make sure the socket id meets all the requirements, such as not being empty, being EOS_SOCKETID_SOCKETNAME_SIZE - 1 characters or less, and only containing alpha-numeric characters. It will throw an error if at least one of these requirements are not met.