### PR TITLE
Fix ambiguous use of CharString operator when exporting for armeabi-v7a

### DIFF
--- a/src/eosg_multiplayer_peer.cpp
+++ b/src/eosg_multiplayer_peer.cpp
@@ -1242,7 +1242,7 @@ bool EOSGMultiplayerPeer::EOSGSocket::_socket_id_is_valid(const String &socket_i
     int alpha_lowercase_range_max = 122;
 
     CharString str = socket_id.ascii();
-    for (int i = 0; i < str.length(); i++) {
+    for (int64_t i = 0; i < str.length(); i++) {
         if (str[i] >= numeric_range_min && str[i] <= numeric_range_max) {
             continue;
         } else if (str[i] >= alpha_capitalized_range_min && str[i] <= alpha_capitalized_range_max) {


### PR DESCRIPTION
When exporting for other platforms/archs the `CharString `"[]" operator accepts `int`s as values. But when exporting the project for android armeabi-v7a (arm32) the compiler errors out:
```
src\eosg_multiplayer_peer.cpp:1246:47: error: use of overloaded operator '[]' is ambiguous (with operand types 'godot::CharString' (aka 'CharStringT<char>') and 'int')
        if (str[i] >= numeric_range_min && str[i] <= numeric_range_max) {
                                           ~~~^~
```
Using `int64_t` as seen on the godot-cpp header fixes the error and consents exporting to armeabi-v7a (tested on my 32-bit phone).