### PR TITLE
Allow overriding default scope_flags in login_persistent_auth_async

### DIFF
--- a/sample/addons/epic-online-services-godot/heos/hauth.gd
+++ b/sample/addons/epic-online-services-godot/heos/hauth.gd
@@ -250,8 +250,8 @@ func login_persistent_auth_async() -> bool:
 	var opts = EOS.Auth.LoginOptions.new()
 	opts.credentials = EOS.Auth.Credentials.new()
 	opts.credentials.type = EOS.Auth.LoginCredentialType.PersistentAuth
-	opts.scope_flags = EOS.Auth.ScopeFlags.BasicProfile | EOS.Auth.ScopeFlags.Presence | EOS.Auth.ScopeFlags.FriendsList
-	opts.login_flags = EOS.Auth.LoginFlags.NoUserInterface
+	opts.scope_flags = auth_login_scope_flags
+	opts.login_flags = auth_login_flags
 
 	return await login_async(opts)
 


### PR DESCRIPTION
The function `login_persistent_auth_async` didn't allow overriding the default scope/login flags. This PR makes it use the `auth_login_scope_flags` and `auth_login_flags` variables like `login_devtool_async` and `login_account_portal_async`.