### PR TITLE
Fix EOSG_GET_STRING to use String::utf8 for C strings

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -22,7 +22,7 @@ using namespace godot;
 #define VARIANT_TO_CHARSTRING(str) ((String)str).utf8()
 #define VARIANT_TO_EOS_BOOL(var) \
     ((var.get_type() == Variant::BOOL) ? ((var.operator bool()) ? EOS_TRUE : EOS_FALSE) : EOS_FALSE)
-#define EOSG_GET_STRING(str) ((str == nullptr) ? String("") : String(str))
+#define EOSG_GET_STRING(str) ((str == nullptr) ? String("") : String::utf8(str))
 #define EOSG_GET_BOOL(eosBool) ((eosBool == EOS_TRUE) ? true : false)
 
 #ifdef _MSC_VER // Check if using Microsoft Visual Studio


### PR DESCRIPTION
Fixed the incorrect name display.

The account name and lobby name which conclude Chinese Character was shown incorrectly cause haven't convert encoding in Windows between ANSI and UTF-8.

e.g. The "我是Amあの"'s display is "ææ¯Amãã®".