### PR TITLE
Improve Linux portability by linking libstdc++ statically

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -100,6 +100,7 @@ if env["platform"] == "windows":
 	env.Append(LIBS=["EOSSDK-Win64-Shipping"])
 
 elif env["platform"] == "linux":
+	env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
 	if env["arch"] == "arm64":
 		env.Append(LIBS=["EOSSDK-LinuxArm64-Shipping"])
 	else:


### PR DESCRIPTION
Added -static-libstdc++ (and -static-libgcc) to ensure C++ runtime compatibility (GLIBCXX).

This allows the addon to run on a wider range of Linux distributions without requiring the latest system libraries.