### PR TITLE
Fix EOSG unload crash by avoiding manual singleton memdelete

### DIFF
--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -59,8 +59,12 @@ void uninitialize_eosg_module(ModuleInitializationLevel p_level) {
 
     Engine::get_singleton()->unregister_singleton("EOSGPacketPeerMediator");
     Engine::get_singleton()->unregister_singleton("IEOS");
-    memdelete(_mediator);
-    memdelete(_ieos);
+
+    // NOTE: do not manually memdelete these singleton instances here.
+    // They are Object-based and will be cleaned up by Godot's object lifecycle.
+    // Manual deletion during extension unload can trigger shutdown crashes.
+    _mediator = nullptr;
+    _ieos = nullptr;
 }
 
 extern "C" {


### PR DESCRIPTION
Title: Fix crash on GDExtension unload by avoiding manual singleton deletion
Closes #64

## Summary
This PR fixes a shutdown/unload crash by changing EOSG module uninitialization to stop manually deleting singleton instances in uninitialize_eosg_module.

## Problem
On Godot 4.6.1 (official), projects including EOSG could crash during editor/headless export teardown and/or runtime exit with a native crash (signal 11) in shutdown paths.

## Root Cause (suspected)
IEOS and EOSGPacketPeerMediator are Object-based singletons. Manually calling memdelete during extension unload appears to conflict with Godot’s object lifecycle/instance binding cleanup, causing invalid lifetime behavior on shutdown.

## Fix
- Keep singleton unregistration:
  - Engine::get_singleton()->unregister_singleton("EOSGPacketPeerMediator")
  - Engine::get_singleton()->unregister_singleton("IEOS")
- Remove manual memdelete(_mediator) / memdelete(_ieos) at unload.
- Null out pointers after unregister.

## Validation
- Reproduced crash before this change in minimal repro and project exports.
- After this change:
  - Headless export completed and produced artifacts.
  - Runtime quit path no longer reproduced the crash in tested setup.
- No SDK/version bump is included in this PR; this is lifecycle-only.

## Scope
- Minimal targeted fix in one file: src/register_types.cpp