### PR TITLE
Fix plugin failing to load on Godot 4.7 (stricter GDScript type inference)

### DIFF
--- a/sample/addons/epic-online-services-godot/eos.gd
+++ b/sample/addons/epic-online-services-godot/eos.gd
@@ -358,7 +358,7 @@ class Connect:
 		static func get_logged_in_users_count() -> int:
 			return IEOS.connect_interface_get_logged_in_users_count()
 
-		static func get_login_status(local_user_id := EOSGRuntime.local_product_user_id) -> LoginStatus:
+		static func get_login_status(local_user_id: String = EOSGRuntime.local_product_user_id) -> LoginStatus:
 			return IEOS.connect_interface_get_login_status(local_user_id)
 
 		static func get_product_user_external_account_count(options: GetProductUserExternalAccountCountOptions = GetProductUserExternalAccountCountOptions.new()) -> int:
@@ -528,7 +528,7 @@ class Auth:
 		static func copy_id_token(options: CopyIdTokenOptions) -> Dictionary:
 			return IEOS.auth_interface_copy_id_token(options)
 
-		static func copy_user_auth_token(options: CopyUserAuthTokenOptions, local_user_id := EOSGRuntime.local_epic_account_id) -> Dictionary:
+		static func copy_user_auth_token(options: CopyUserAuthTokenOptions, local_user_id: String = EOSGRuntime.local_epic_account_id) -> Dictionary:
 			var func_result: Dictionary = IEOS.auth_interface_copy_user_auth_token(
 				options, local_user_id
 			)
@@ -557,16 +557,16 @@ class Auth:
 		static func get_logged_in_accounts_count() -> int:
 			return IEOS.auth_interface_get_logged_in_accounts_count()
 
-		static func get_login_status(local_user_id := EOSGRuntime.local_epic_account_id) -> LoginStatus:
+		static func get_login_status(local_user_id: String = EOSGRuntime.local_epic_account_id) -> LoginStatus:
 			return IEOS.auth_interface_get_login_status(local_user_id)
 
 		static func get_merged_account_by_index(local_user_id: String, index: int) -> String:
 			return IEOS.auth_interface_get_merged_account_by_index(local_user_id, index)
 
-		static func get_merged_accounts_count(local_user_id := EOSGRuntime.local_epic_account_id) -> int:
+		static func get_merged_accounts_count(local_user_id: String = EOSGRuntime.local_epic_account_id) -> int:
 			return IEOS.auth_interface_get_merged_accounts_count(local_user_id)
 
-		static func get_selected_account_id(local_user_id := EOSGRuntime.local_epic_account_id) -> Dictionary:
+		static func get_selected_account_id(local_user_id: String = EOSGRuntime.local_epic_account_id) -> Dictionary:
 			return IEOS.auth_interface_get_selected_account_id(local_user_id)
 
 		static func link_account(options: LinkAccountOptions) -> void:
@@ -1548,7 +1548,7 @@ class Lobby:
 
 		var allow_invites := true
 		var enable_join_by_id := true
-		var local_user_id := EOSGRuntime.local_product_user_id
+		var local_user_id: String = EOSGRuntime.local_product_user_id
 		var permission_level: LobbyPermissionLevel = LobbyPermissionLevel.PublicAdvertised
 		var presence_enabled := true
 


### PR DESCRIPTION
## Problem

The plugin fails to load on **Godot 4.7 stable**. On import every `heos/*.gd` autoload (HAuth, HPlatform, HLobbies, HP2P, ...) reports a parse error and the plugin never initialises:

```
Parse Error: Cannot infer the type of "local_user_id" parameter because the value doesn't have a set type.
  at: eos.gd:361, 531, 560, 566, 569, 1551
Parse Error: Could not resolve external class member "copy_user_auth_token"
  Failed to load script ".../heos/hauth.gd" with error "Parse error".
```

## Cause

Godot 4.7 tightened GDScript type inference. It no longer infers a variable or parameter type from a **native GDExtension property** used as a default value. Six declarations in `eos.gd` use `:=` with `EOSGRuntime.local_product_user_id` / `EOSGRuntime.local_epic_account_id` as the default, e.g.

```gdscript
static func get_login_status(local_user_id := EOSGRuntime.local_product_user_id) -> LoginStatus:
```

The parser can no longer determine the static type of that native property, so the inference fails. Because `eos.gd` defines the `EOS` class, the failure cascades into every high-level wrapper that references `EOS.*` (hence the `copy_user_auth_token` / `HAuth` errors), and the autoloads collapse.

## Fix

Annotate the six declarations with an explicit `String` type. These ids are plain strings everywhere else in the API (e.g. `get_merged_account_by_index(local_user_id: String, ...)`), and the default values are unchanged, so behaviour on 4.2–4.6 is identical:

```gdscript
static func get_login_status(local_user_id: String = EOSGRuntime.local_product_user_id) -> LoginStatus:
```

## Testing

Verified against **Godot 4.7 stable** (`4.7.stable.official`): the plugin imports cleanly, all `H*` autoloads boot with no parse errors, and the native `EOS` / `IEOS` / `EOSGRuntime` classes register as before. The existing 4.2-built GDExtension binary loads fine on 4.7 under the usual backward-compatibility rules; this was purely a GDScript parser change.
