### PR TITLE
CI: use NDK r28b to match godot-cpp 4.5's default ndk_version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
         if: ${{ matrix.platform == 'android' }}
         uses: nttld/setup-ndk@v1
         with:
-          ndk-version: r28
+          ndk-version: r28b
           link-to-sdk: true
 
       - name: Setup build cache


### PR DESCRIPTION
Follow-up to #71 — fixes the four Android jobs that fail on main since the merge (run 31035838240, the `Could not find NDK toolchain at .../ndk/28.1.13356709` error).

godot-cpp 4.5 resolves the NDK as `ANDROID_HOME/ndk/<ndk_version>` with a default of `28.1.13356709` whenever `ANDROID_HOME` is set — which is always true on GitHub runners. `setup-ndk` with plain `r28` installs 28.0.x, so the lookup fails. `r28b` is exactly **28.1.13356709**, so the version linked into the SDK matches godot-cpp's default. (godot-cpp 4.2 reads `ANDROID_NDK_ROOT` directly, which is why the non-Android platforms are green.)

One-line change; no source changes.