### PR TITLE
Fix delete_persistent_auth always failing with InvalidParameters

### DIFF
--- a/src/auth_interface.cpp
+++ b/src/auth_interface.cpp
@@ -121,7 +121,7 @@ void IEOS::auth_interface_delete_persistent_auth(Ref<RefCounted> p_options) {
     options.ApiVersion = EOS_AUTH_DELETEPERSISTENTAUTH_API_LATEST;
     options.RefreshToken = nullptr;
 
-    if (refresh_token.size() != 0) {
+    if (refresh_token.length() != 0) {
         options.RefreshToken = refresh_token.get_data();
     }
     p_options->reference();


### PR DESCRIPTION
Bug

IEOS::auth_interface_delete_persistent_auth checks refresh_token.size() != 0 to decide whether to leave options.RefreshToken as nullptr. But CharString::size() in Godot always includes one byte for its terminator, i.e. size is always at least 1.

This means options.RefreshToken is always set to a non-null pointer, which the EOS SDK rejects with InvalidParameters on Desktop/Mobile platforms (RefreshToken must be NULL there according to the SDK docs, it's only supported on console).

Fix

if (refresh_token.length() != 0) { // was: refresh_token.size() != 0 options.RefreshToken = refresh_token.get_data();
}

Fixes #73 